### PR TITLE
Update passport-oauth dependency to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,11 @@
   "name": "passport-qq",
   "version": "0.0.1",
   "description": "qq authentication strategy for Passport.",
-  "author": { "name": "Andy Shang", "email": "andy.amuro@gmail.com", "url": "http://github.com/andyshang" },
+  "author": {
+    "name": "Andy Shang",
+    "email": "andy.amuro@gmail.com",
+    "url": "http://github.com/andyshang"
+  },
   "repository": {
     "type": "git",
     "url": "http://github.com/andyshang/passport-qq.git"
@@ -12,8 +16,8 @@
   },
   "main": "./lib/passport-qq",
   "dependencies": {
-    "pkginfo": "0.2.x",
-    "passport-oauth": "0.1.x"
+    "passport-oauth": "^1.0.0",
+    "pkginfo": "0.2.x"
   },
   "devDependencies": {
     "vows": "0.6.x"
@@ -21,10 +25,21 @@
   "scripts": {
     "test": "NODE_PATH=lib node_modules/.bin/vows test/*-test.js"
   },
-  "engines": { "node": ">= 0.4.0" },
-  "licenses": [ {
-    "type": "MIT",
-    "url": "http://www.opensource.org/licenses/MIT" 
-  } ],
-  "keywords": ["passport", "qq", "auth", "authn", "authentication", "identity"]
+  "engines": {
+    "node": ">= 0.4.0"
+  },
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "http://www.opensource.org/licenses/MIT"
+    }
+  ],
+  "keywords": [
+    "passport",
+    "qq",
+    "auth",
+    "authn",
+    "authentication",
+    "identity"
+  ]
 }


### PR DESCRIPTION
解决 passport 升级 0.3.0 之后，passport-qq 不兼容的问题，详见：https://github.com/jaredhanson/passport/issues/400
